### PR TITLE
Fix GetBookings query field typo

### DIFF
--- a/get_bookings.go
+++ b/get_bookings.go
@@ -33,7 +33,7 @@ func (c *Client) NewGetBookingsQueryParams() *GetBookingsQueryParams {
 
 type GetBookingsQueryParams struct {
 	ReservationID string   `schema:"reservationId,omitempty"`
-	GroupdID      string   `schema:"groupId,omitempty"`
+	GroupID       string   `schema:"groupId,omitempty"`
 	ChannelCode   []string `schema:"channelCode,omitempty"`
 	ExternalCode  string   `schema:"externalCode,omitempty"`
 	TextSearch    string   `schema:"textSearch,omitempty"`

--- a/get_bookings_nsfw.go
+++ b/get_bookings_nsfw.go
@@ -33,7 +33,7 @@ func (c *Client) NewGetBookingsNSFWQueryParams() *GetBookingsNSFWQueryParams {
 
 type GetBookingsNSFWQueryParams struct {
 	ReservationID string   `schema:"reservationId,omitempty"`
-	GroupdID      string   `schema:"groupId,omitempty"`
+	GroupID       string   `schema:"groupId,omitempty"`
 	ChannelCode   []string `schema:"channelCode,omitempty"`
 	ExternalCode  string   `schema:"externalCode,omitempty"`
 	TextSearch    string   `schema:"textSearch,omitempty"`


### PR DESCRIPTION
## Summary
- rename `GroupdID` field to `GroupID` in booking requests

## Testing
- `go vet ./...` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*
