### PR TITLE
fix: Correct GroupdID typo to GroupID

### DIFF
--- a/get_bookings.go
+++ b/get_bookings.go
@@ -33,7 +33,7 @@ func (c *Client) NewGetBookingsQueryParams() *GetBookingsQueryParams {
 
 type GetBookingsQueryParams struct {
 	ReservationID string   `schema:"reservationId,omitempty"`
-	GroupdID      string   `schema:"groupId,omitempty"`
+	GroupID       string   `schema:"groupId,omitempty"`
 	ChannelCode   []string `schema:"channelCode,omitempty"`
 	ExternalCode  string   `schema:"externalCode,omitempty"`
 	TextSearch    string   `schema:"textSearch,omitempty"`

--- a/get_bookings_nsfw.go
+++ b/get_bookings_nsfw.go
@@ -33,7 +33,7 @@ func (c *Client) NewGetBookingsNSFWQueryParams() *GetBookingsNSFWQueryParams {
 
 type GetBookingsNSFWQueryParams struct {
 	ReservationID string   `schema:"reservationId,omitempty"`
-	GroupdID      string   `schema:"groupId,omitempty"`
+	GroupID       string   `schema:"groupId,omitempty"`
 	ChannelCode   []string `schema:"channelCode,omitempty"`
 	ExternalCode  string   `schema:"externalCode,omitempty"`
 	TextSearch    string   `schema:"textSearch,omitempty"`


### PR DESCRIPTION
Corrected a typo in the field name GroupdID to GroupID in the following files:
- get_bookings.go
- get_bookings_nsfw.go

This affects the GetBookingsQueryParams and GetBookingsNSFWQueryParams structs, specifically the schema tag for the GroupID field.